### PR TITLE
Add automated coverage for Vistoria screen

### DIFF
--- a/cypress/e2e/vistoria.cy.js
+++ b/cypress/e2e/vistoria.cy.js
@@ -1,0 +1,111 @@
+const ENDPOINT = '**/consultar/dadosLaudoVeiculo/**';
+
+const visitVistoria = (fixtureName, token) => {
+  cy.intercept('GET', ENDPOINT, { fixture: fixtureName }).as('getVistoria');
+  cy.visit(`/vistoria/${token}`);
+  cy.wait('@getVistoria').its('response.statusCode').should('eq', 200);
+  cy.title().should('eq', 'Acompanhamento da Vistoria');
+};
+
+describe('Tela de Vistoria', () => {
+  it('exibe dados completos quando a vistoria foi solicitada', () => {
+    visitVistoria('vistoria-solicitado.json', 'token-solicitado');
+
+    cy.contains('INFORMAÇÕES DA VISTORIA').should('be.visible');
+    cy.get('app-step-by-step-sm .step')
+      .eq(0)
+      .should('have.class', 'active')
+      .and('not.have.class', 'done');
+    cy.get('app-step-by-step-sm .step').eq(1).should('not.have.class', 'done');
+
+    cy.contains(/Recebemos sua solicitação/i).should('be.visible');
+
+    cy.contains('h4', /^Modelo$/)
+      .parent()
+      .within(() => {
+        cy.contains('Uno Way 1.0');
+      });
+    cy.contains('h4', /^Ano fabricação \/ Modelo$/)
+      .parent()
+      .within(() => {
+        cy.contains('2022');
+        cy.contains('2023');
+      });
+    cy.contains('h4', /^Proprietário$/)
+      .parent()
+      .within(() => {
+        cy.contains('João Silva');
+      });
+    cy.contains('h4', /^Contato$/)
+      .parent()
+      .within(() => {
+        cy.contains('(11) 91234-5678');
+      });
+    cy.contains('h4', /^Localidade$/)
+      .parent()
+      .within(() => {
+        cy.contains('Cariacica - ES');
+      });
+    cy.contains('h4', /^Solicitação$/)
+      .parent()
+      .find('span')
+      .invoke('text')
+      .should('match', /\d{2}\/\d{2}\/\d{4}/);
+    cy.contains('h4', /^Vistoria$/)
+      .parent()
+      .find('span')
+      .should('contain', 'Não realizada');
+
+    cy.contains('SALVAR PDF').should('not.exist');
+  });
+
+  it('mostra o progresso quando a vistoria está agendada', () => {
+    visitVistoria('vistoria-agendado.json', 'token-agendado');
+
+    cy.get('app-step-by-step-sm .step').eq(0).should('have.class', 'done');
+    cy.get('app-step-by-step-sm .step').eq(1).should('have.class', 'active');
+    cy.get('app-step-by-step-sm .step').eq(2).should('not.have.class', 'done');
+
+    cy.contains(/vistoria já está agendada/i).should('be.visible');
+    cy.contains('h4', /^Vistoria$/)
+      .parent()
+      .find('span')
+      .should('contain', '12/05/2024');
+    cy.get('img[alt="Peugeot 208"]')
+      .should('have.attr', 'src')
+      .and('include', 'peugeot208.png');
+    cy.contains('SALVAR PDF')
+      .should('have.attr', 'href', 'https://example.com/laudo-agendado.pdf')
+      .and('have.attr', 'target', 'blank');
+  });
+
+  it('destaca a etapa correta quando a vistoria foi realizada', () => {
+    visitVistoria('vistoria-vistoriado.json', 'token-vistoriado');
+
+    cy.get('app-step-by-step-sm .step').eq(0).should('have.class', 'done');
+    cy.get('app-step-by-step-sm .step').eq(1).should('have.class', 'done');
+    cy.get('app-step-by-step-sm .step').eq(2).should('have.class', 'active');
+
+    cy.contains(/Já realizamos sua vistoria/i).should('be.visible');
+    cy.contains('h4', /^Vistoria$/)
+      .parent()
+      .find('span')
+      .should('contain', '25/03/2024');
+  });
+
+  it('marca todas as etapas quando o laudo foi finalizado', () => {
+    visitVistoria('vistoria-finalizado.json', 'token-finalizado');
+
+    cy.get('app-step-by-step-sm .step').each(($step, index) => {
+      if (index < 3) {
+        cy.wrap($step).should('have.class', 'done');
+      } else {
+        cy.wrap($step).should('have.class', 'active');
+      }
+    });
+    cy.get('.container.py-5.text-center').should('not.exist');
+    cy.contains('SALVAR PDF')
+      .should('have.attr', 'href', 'https://example.com/laudo-final.pdf')
+      .and('have.attr', 'target', 'blank');
+  });
+});

--- a/cypress/fixtures/vistoria-agendado.json
+++ b/cypress/fixtures/vistoria-agendado.json
@@ -1,0 +1,15 @@
+{
+  "status": "AGENDADO",
+  "cidade": "vila_velha",
+  "marca": "Peugeot 208",
+  "placa": "DEF4G56",
+  "modelo": "208 Allure",
+  "anoFabricacao": 2021,
+  "anoModelo": 2022,
+  "nomeProprietario": "Maria Souza",
+  "telefone": "(21) 93456-7890",
+  "uf": "ES",
+  "dataSolicitacao": "2024-04-10",
+  "dataVistoria": "2024-05-12",
+  "tokenPdf": "https://example.com/laudo-agendado.pdf"
+}

--- a/cypress/fixtures/vistoria-finalizado.json
+++ b/cypress/fixtures/vistoria-finalizado.json
@@ -1,0 +1,15 @@
+{
+  "status": "LAUDO_FINALIZADO",
+  "cidade": "sp_regiao_metropolitada",
+  "marca": "Ford Ka",
+  "placa": "JKL1M23",
+  "modelo": "Ka 1.0",
+  "anoFabricacao": 2019,
+  "anoModelo": 2019,
+  "nomeProprietario": "Ana Pereira",
+  "telefone": "(11) 92345-6789",
+  "uf": "SP",
+  "dataSolicitacao": "2024-01-05",
+  "dataVistoria": "2024-01-08",
+  "tokenPdf": "https://example.com/laudo-final.pdf"
+}

--- a/cypress/fixtures/vistoria-solicitado.json
+++ b/cypress/fixtures/vistoria-solicitado.json
@@ -1,0 +1,15 @@
+{
+  "status": "SOLICITADO",
+  "cidade": "cariacica",
+  "marca": "Fiat Uno",
+  "placa": "ABC1D23",
+  "modelo": "Uno Way 1.0",
+  "anoFabricacao": 2022,
+  "anoModelo": 2023,
+  "nomeProprietario": "João Silva",
+  "telefone": "(11) 91234-5678",
+  "uf": "ES",
+  "dataSolicitacao": "2024-05-01",
+  "dataVistoria": null,
+  "tokenPdf": null
+}

--- a/cypress/fixtures/vistoria-vistoriado.json
+++ b/cypress/fixtures/vistoria-vistoriado.json
@@ -1,0 +1,15 @@
+{
+  "status": "VISTORIADO",
+  "cidade": "serra",
+  "marca": "Chevrolet Onix",
+  "placa": "GHI7J89",
+  "modelo": "Onix LT",
+  "anoFabricacao": 2020,
+  "anoModelo": 2021,
+  "nomeProprietario": "Carlos Lima",
+  "telefone": "(27) 98765-4321",
+  "uf": "ES",
+  "dataSolicitacao": "2024-03-20",
+  "dataVistoria": "2024-03-25",
+  "tokenPdf": "https://example.com/laudo-vistoriado.pdf"
+}

--- a/src/app/vistoria/vistoria.component.spec.ts
+++ b/src/app/vistoria/vistoria.component.spec.ts
@@ -21,7 +21,20 @@ describe("VistoriaComponent", () => {
 
   beforeEach(waitForAsync(() => {
     laudoServiceSpy.getLaudo.and.returnValue(
-      Promise.resolve({ status: "SOLICITADO", cidade: "c1", marca: "Fiat Uno" })
+      Promise.resolve({
+        status: "SOLICITADO",
+        cidade: "c1",
+        marca: "Fiat Uno",
+        placa: "ABC1D23",
+        modelo: "Uno",
+        anoFabricacao: 2022,
+        anoModelo: 2023,
+        nomeProprietario: "João",
+        telefone: "11999999999",
+        uf: "ES",
+        dataSolicitacao: "2024-05-01T00:00:00",
+        dataVistoria: null,
+      })
     );
     laudoServiceSpy.getCidadeNome.and.returnValue("Cidade Teste");
 
@@ -61,8 +74,10 @@ describe("VistoriaComponent", () => {
         "Visualize o status da vistoria veicular, incluindo etapas como agendamento, realização e entrega do laudo.",
     });
     expect(laudoServiceSpy.getLaudo).toHaveBeenCalledWith("tokenABC");
+    expect(component.token).toBe("tokenABC");
     expect(laudoServiceSpy.getCidadeNome).toHaveBeenCalledWith("c1");
     expect(component.dados.cidade).toBe("Cidade Teste");
+    expect(component.statusText).toContain("Recebemos sua solicitação");
     expect(component.stepIndex).toBe(0);
     expect(component.fotoMarca).toBe(
       "./assets/images/marcas/fiatuno.png"
@@ -91,8 +106,10 @@ describe("VistoriaComponent", () => {
     expect(component.statusText).toBe("");
     expect(component.laudoDesc).toBe("Finalizado");
 
+    const previousStatus = component.statusText;
     component.setStepIndex("DESCONHECIDO");
     expect(component.laudoDesc).toBe("DESCONHECIDO");
+    expect(component.statusText).toBe(previousStatus);
   });
 
   it("should set fotoMarca path correctly", () => {
@@ -104,6 +121,11 @@ describe("VistoriaComponent", () => {
     component.setFotoMarca(null);
     expect(component.fotoMarca).toBe(
       "./assets/images/marcas/semmarca.png"
+    );
+
+    component.setFotoMarca("Peugeot 208");
+    expect(component.fotoMarca).toBe(
+      "./assets/images/marcas/peugeot208.png"
     );
   });
 });


### PR DESCRIPTION
## Summary
- strengthen Vistoria component unit specs to assert status messaging, token handling, and brand sanitization
- add Cypress end-to-end scenarios that exercise all vistoria status flows using mocked API responses
- provide dedicated fixtures for each vistoria status to validate timeline and PDF behaviours

## Testing
- `npm run coverage` *(fails: npm returned 403 Forbidden when downloading Angular CLI)*

------
https://chatgpt.com/codex/tasks/task_b_68c86cd20df88320a295316de4a344c2