### PR TITLE
test: add FAQ unit and e2e coverage

### DIFF
--- a/cypress/e2e/duvidas-frequentes.cy.js
+++ b/cypress/e2e/duvidas-frequentes.cy.js
@@ -1,0 +1,81 @@
+const FAQ_COUNT = 26;
+const META_DESCRIPTION =
+  'Encontre respostas para as perguntas mais comuns sobre nossas consultas veiculares, planos e formas de pagamento.';
+
+describe('Dúvidas frequentes page', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/painel/**', req => {
+      if (req.url.includes('getPosts')) {
+        req.reply({ statusCode: 200, body: { posts: [], totalDePosts: 0 } });
+      } else if (req.url.includes('getCategorias')) {
+        req.reply({ statusCode: 200, body: { listaDeCategorias: [] } });
+      } else if (req.url.includes('getPostsByCategoria')) {
+        req.reply({ statusCode: 200, body: { posts: [], totalDePosts: 0 } });
+      } else {
+        req.reply({ statusCode: 200, body: {} });
+      }
+    }).as('apiPainel');
+
+    cy.visit('/duvidas-frequentes');
+  });
+
+  it('displays the FAQ heading and metadata', () => {
+    cy.contains('h1', 'Perguntas frequentes').should('be.visible');
+    cy.title().should('eq', 'Dúvidas Frequentes | CarCheck');
+    cy.get('meta[name="description"]').should('have.attr', 'content', META_DESCRIPTION);
+  });
+
+  it('renders the entire FAQ list collapsed by default', () => {
+    cy.get('.card').should('have.length', FAQ_COUNT);
+    cy.get('.card').first().within(() => {
+      cy.get('.question-text').should(
+        'contain',
+        'O que é o Carcheck Brasil?'
+      );
+    });
+    cy.get('.card .accordion-body-wrapper.open').should('not.exist');
+    cy.get('.card .icon.rotar').should('not.exist');
+  });
+
+  it('toggles different FAQ cards when clicking their headers', () => {
+    cy.get('.card').eq(0).as('firstCard');
+    cy.get('.card').eq(1).as('secondCard');
+
+    cy.get('@firstCard').find('.card-header').click();
+    cy.get('@firstCard')
+      .find('.accordion-body-wrapper')
+      .should('have.class', 'open');
+    cy.get('@firstCard').find('.icon').should('have.class', 'rotar');
+
+    cy.get('@secondCard').find('.card-header').click();
+    cy.get('@secondCard')
+      .find('.accordion-body-wrapper')
+      .should('have.class', 'open');
+    cy.get('@secondCard').find('.icon').should('have.class', 'rotar');
+
+    cy.get('@firstCard')
+      .find('.accordion-body-wrapper')
+      .should('not.have.class', 'open');
+    cy.get('@firstCard').find('.icon').should('not.have.class', 'rotar');
+  });
+
+  it('allows toggling the same FAQ repeatedly', () => {
+    cy.get('.card').eq(0).as('firstCard');
+
+    cy.get('@firstCard').find('.card-header').click();
+    cy.get('@firstCard')
+      .find('.accordion-body-wrapper')
+      .should('have.class', 'open');
+
+    cy.get('@firstCard').find('.card-header').click();
+    cy.get('@firstCard')
+      .find('.accordion-body-wrapper')
+      .should('not.have.class', 'open');
+
+    cy.get('@firstCard').find('.card-header').click();
+    cy.get('@firstCard')
+      .find('.accordion-body-wrapper')
+      .should('have.class', 'open');
+    cy.get('@firstCard').find('.icon').should('have.class', 'rotar');
+  });
+});

--- a/src/app/duvidas-frequentes/duvidas-frequentes.component.spec.ts
+++ b/src/app/duvidas-frequentes/duvidas-frequentes.component.spec.ts
@@ -1,97 +1,113 @@
-import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
-import { By } from "@angular/platform-browser";
-import { Title, Meta } from "@angular/platform-browser";
-import { DuvidasFrequentesComponent } from "./duvidas-frequentes.component";
-import { faqs } from "../utils/faqs";
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By, Title, Meta } from '@angular/platform-browser';
+import { DuvidasFrequentesComponent } from './duvidas-frequentes.component';
+import { faqs } from '../utils/faqs';
 
-describe("DuvidasFrequentesComponent", () => {
+describe('DuvidasFrequentesComponent', () => {
   let component: DuvidasFrequentesComponent;
   let fixture: ComponentFixture<DuvidasFrequentesComponent>;
   let titleService: Title;
   let metaService: Meta;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [DuvidasFrequentesComponent],
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DuvidasFrequentesComponent],
       providers: [Title, Meta],
     }).compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(DuvidasFrequentesComponent);
     component = fixture.componentInstance;
     titleService = TestBed.inject(Title);
     metaService = TestBed.inject(Meta);
 
-    spyOn(titleService, "setTitle").and.callThrough();
-    spyOn(metaService, "updateTag").and.callThrough();
+    spyOn(titleService, 'setTitle').and.callThrough();
+    spyOn(metaService, 'updateTag').and.callThrough();
 
     fixture.detectChanges();
   });
 
-  it("should create", () => {
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it("should set page title on init", () => {
-    expect(titleService.setTitle).toHaveBeenCalledWith(
-      "Dúvidas Frequentes | CarCheck"
-    );
-    expect(titleService.getTitle()).toBe("Dúvidas Frequentes | CarCheck");
+  it('should expose FAQ data for the template', () => {
+    expect(component.listaFaqs).toBe(faqs);
+
+    const cards = fixture.debugElement.queryAll(By.css('.card'));
+    expect(cards.length).toBe(faqs.length);
+
+    const firstQuestion = cards[0]
+      .query(By.css('.question-text'))
+      .nativeElement as HTMLElement;
+    expect(firstQuestion.textContent).toContain(faqs[0].question);
+
+    cards.forEach(card => {
+      const bodyWrapper = card.query(By.css('.accordion-body-wrapper'));
+      expect(bodyWrapper.classes['open']).toBeFalsy();
+    });
   });
 
-  it("should update meta description tag on init", () => {
+  it('should set page metadata on init', () => {
     const expectedDescription =
-      "Encontre respostas para as perguntas mais comuns sobre nossas consultas veiculares, planos e formas de pagamento.";
+      'Encontre respostas para as perguntas mais comuns sobre nossas consultas veiculares, planos e formas de pagamento.';
+
+    expect(titleService.setTitle).toHaveBeenCalledWith(
+      'Dúvidas Frequentes | CarCheck'
+    );
+    expect(titleService.getTitle()).toBe('Dúvidas Frequentes | CarCheck');
 
     expect(metaService.updateTag).toHaveBeenCalledWith({
-      name: "description",
+      name: 'description',
       content: expectedDescription,
     });
 
     const descriptionTag = metaService.getTag('name="description"');
-    expect(descriptionTag?.getAttribute("content")).toBe(expectedDescription);
+    expect(descriptionTag?.getAttribute('content')).toBe(expectedDescription);
   });
 
-  it("should render all FAQ items", () => {
-    const cards = fixture.debugElement.queryAll(By.css(".card"));
-    expect(cards.length).toBe(faqs.length);
+  it('should toggle cards via the component method', () => {
+    expect(component.activeCard).toBe('');
 
-    const firstQuestion = cards[0].query(By.css(".question-text"))
-      .nativeElement as HTMLElement;
-    expect(firstQuestion.textContent).toContain(faqs[0].question);
+    component.toggleCard('collapse1');
+    expect(component.activeCard).toBe('collapse1');
+
+    component.toggleCard('collapse1');
+    expect(component.activeCard).toBe('');
+
+    component.toggleCard('collapse2');
+    expect(component.activeCard).toBe('collapse2');
+
+    component.toggleCard('collapse1');
+    expect(component.activeCard).toBe('collapse1');
   });
 
-  it("should toggle card state", () => {
-    expect(component.activeCard).toBe("");
-    component.toggleCard("collapse1");
-    expect(component.activeCard).toBe("collapse1");
-    component.toggleCard("collapse1");
-    expect(component.activeCard).toBe("");
-    component.toggleCard("collapse1");
-    component.toggleCard("collapse2");
-    expect(component.activeCard).toBe("collapse2");
-  });
-
-  it("should open and close card on click", () => {
-    const headers = fixture.debugElement.queryAll(By.css(".card-header"));
-    const bodies = fixture.debugElement.queryAll(
-      By.css(".accordion-body-wrapper")
+  it('should reflect toggle interactions in the view', () => {
+    const headers = fixture.debugElement.queryAll(By.css('.card-header'));
+    const wrappers = fixture.debugElement.queryAll(
+      By.css('.accordion-body-wrapper')
     );
-    const icon = headers[0].query(By.css(".icon")).nativeElement as HTMLElement;
+    const firstIcon = headers[0].query(By.css('.icon')).nativeElement as HTMLElement;
+    const secondIcon = headers[1].query(By.css('.icon')).nativeElement as HTMLElement;
 
-    // initially closed
-    expect(bodies[0].classes["open"]).toBeFalsy();
-    expect(icon.classList.contains("rotar")).toBeFalsy();
+    expect(wrappers[0].classes['open']).toBeFalsy();
+    expect(firstIcon.classList.contains('rotar')).toBeFalse();
+    expect(secondIcon.classList.contains('rotar')).toBeFalse();
 
-    headers[0].triggerEventHandler("click", null);
+    headers[0].triggerEventHandler('click', null);
     fixture.detectChanges();
-    expect(bodies[0].classes["open"]).toBeTruthy();
-    expect(icon.classList.contains("rotar")).toBeTruthy();
+    expect(wrappers[0].classes['open']).toBeTrue();
+    expect(firstIcon.classList.contains('rotar')).toBeTrue();
 
-    headers[1].triggerEventHandler("click", null);
+    headers[1].triggerEventHandler('click', null);
     fixture.detectChanges();
-    expect(bodies[0].classes["open"]).toBeFalsy();
-    expect(bodies[1].classes["open"]).toBeTruthy();
+    expect(wrappers[0].classes['open']).toBeFalse();
+    expect(wrappers[1].classes['open']).toBeTrue();
+    expect(firstIcon.classList.contains('rotar')).toBeFalse();
+    expect(secondIcon.classList.contains('rotar')).toBeTrue();
+
+    headers[1].triggerEventHandler('click', null);
+    fixture.detectChanges();
+    expect(wrappers[1].classes['open']).toBeFalse();
+    expect(secondIcon.classList.contains('rotar')).toBeFalse();
   });
 });


### PR DESCRIPTION
## Summary
- expand the Dúvidas Frequentes unit tests to validate metadata, FAQ rendering, and accordion toggling
- add a dedicated Cypress suite covering FAQ page metadata, list rendering, and interaction behaviour

## Testing
- npm test *(fails: unable to download ng CLI in the offline environment)*
- npm run e2e *(fails: Cypress binary not available in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68c86cd1a8d0832086be143e6154acde