### PR TITLE
test: expand contato coverage

### DIFF
--- a/cypress/e2e/contact.cy.js
+++ b/cypress/e2e/contact.cy.js
@@ -1,4 +1,32 @@
 describe('Contact page', () => {
+  const fillForm = () => {
+    cy.get('input[formControlName="name"]').type('Tester');
+    cy.get('input[formControlName="email"]').type('test@example.com');
+    cy.get('input[formControlName="subject"]').type('Hello');
+    cy.get('textarea[formControlName="message"]').type('Testing message');
+  };
+
+  it('shows validation errors when submitting an empty form', () => {
+    cy.intercept('POST', '**/cliente/enviarContato', () => {
+      throw new Error('Request should not be sent when form is invalid');
+    });
+
+    cy.visit('/contato');
+
+    cy.get('input[formControlName="name"]').focus().blur();
+    cy.get('input[formControlName="email"]').focus().blur();
+    cy.get('input[formControlName="subject"]').focus().blur();
+    cy.get('textarea[formControlName="message"]').focus().blur();
+
+    cy.get('button[type="submit"]').click();
+
+    cy.contains('O nome é obrigatório.').should('be.visible');
+    cy.contains('O e-mail é obrigatório.').should('be.visible');
+    cy.contains('O assunto é obrigatório.').should('be.visible');
+    cy.contains('A mensagem é obrigatória.').should('be.visible');
+    cy.get('.wpcf7-response-output').should('not.exist');
+  });
+
   it('sends a contact message', () => {
     cy.intercept('POST', '**/cliente/enviarContato', {
       statusCode: 200,
@@ -7,10 +35,7 @@ describe('Contact page', () => {
 
     cy.visit('/contato');
 
-    cy.get('input[formControlName="name"]').type('Tester');
-    cy.get('input[formControlName="email"]').type('test@example.com');
-    cy.get('input[formControlName="subject"]').type('Hello');
-    cy.get('textarea[formControlName="message"]').type('Testing message');
+    fillForm();
 
     cy.get('button[type="submit"]').click();
 
@@ -22,5 +47,30 @@ describe('Contact page', () => {
     });
 
     cy.get('.wpcf7-response-output').should('contain', 'Mensagem enviada com sucesso!');
+  });
+
+  it('shows an error message when the request fails', () => {
+    cy.intercept('POST', '**/cliente/enviarContato', {
+      statusCode: 500,
+      body: { message: 'Erro' }
+    }).as('sendContactError');
+
+    cy.visit('/contato');
+
+    fillForm();
+
+    cy.get('button[type="submit"]').click();
+
+    cy.wait('@sendContactError').its('request.body').should('deep.include', {
+      nome: 'Tester',
+      email: 'test@example.com',
+      assunto: 'Hello',
+      mensagem: 'Testing message'
+    });
+
+    cy.get('.wpcf7-response-output').should(
+      'contain',
+      'Erro ao enviar mensagem. Tente novamente mais tarde.'
+    );
   });
 });

--- a/src/app/contato/contato.component.spec.ts
+++ b/src/app/contato/contato.component.spec.ts
@@ -70,12 +70,18 @@ describe("ContatoComponent", () => {
   });
 
   it("should not submit when form is invalid", fakeAsync(() => {
+    const consoleSpy = spyOn(console, "log");
+
     component.contactForm.reset();
     component.submitForm();
     tick();
-    expect(component.showErrors).toBeTruthy();
+
+    expect(component.showErrors).toBeTrue();
     expect(pessoaServiceSpy.enviarContato).not.toHaveBeenCalled();
     expect(component.submitMessage).toBe("");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Formulário inválido. Verifique os campos."
+    );
   }));
 
   it("should submit form and show success message when service resolves", fakeAsync(() => {
@@ -98,6 +104,7 @@ describe("ContatoComponent", () => {
     tick();
 
     expect(pessoaServiceSpy.enviarContato).toHaveBeenCalledWith(expectedBody);
+    expect(component.showErrors).toBeTrue();
     expect(component.submitMessage).toBe("Mensagem enviada com sucesso!");
   }));
 


### PR DESCRIPTION
## Summary
- expand the Cypress coverage for `/contato` to cover validation, success, and failure flows
- strengthen the ContatoComponent unit specs to exercise logging, success state, and error handling paths

## Testing
- `npm install` *(fails: 403 Forbidden when fetching @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_b_68c86cd1736483209d9b3e67082d3e27