### PR TITLE
Add Consulta Veicular Completa tests

### DIFF
--- a/cypress/e2e/consulta-veicular-completa.cy.js
+++ b/cypress/e2e/consulta-veicular-completa.cy.js
@@ -1,0 +1,25 @@
+describe('Consulta Veicular Completa', () => {
+  beforeEach(() => {
+    cy.visit('/produto/consulta-veicular-completa');
+  });
+
+  it('exibe as informações principais do produto', () => {
+    cy.contains('h1', 'Consulta Veicular Completa').should('be.visible');
+
+    cy.get('.consulta').within(() => {
+      cy.contains('RECOMENDADA').should('be.visible');
+      cy.get('.azul').should('contain.text', 'Consulta Veicular Completa');
+      cy.get('.de').invoke('text').should('match', /69,90/);
+      cy.get('.preco').invoke('text').should('match', /54,90/);
+      cy.get('a.btn').should('have.attr', 'href', '/comprar-consulta-placa/completa');
+    });
+  });
+
+  it('mostra seções de suporte à consulta', () => {
+    cy.contains('h1', 'Exemplo de consulta').should('be.visible');
+    cy.contains('h2', 'Como funciona').should('be.visible');
+    cy.contains('h1', 'Perguntas frequentes').should('be.visible');
+    cy.get('app-comparar-produto').should('exist');
+    cy.get('app-produtos').should('exist');
+  });
+});

--- a/src/app/produtos/consulta-veicular-completa/consulta-veicular-completa.component.spec.ts
+++ b/src/app/produtos/consulta-veicular-completa/consulta-veicular-completa.component.spec.ts
@@ -1,0 +1,124 @@
+import { Component, Directive, Input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { ConsultaVeicularCompletaComponent } from "./consulta-veicular-completa.component";
+import { VariableGlobal } from "../../service/variable.global.service";
+
+@Component({
+  selector: "app-exemplo-consulta-completa",
+  standalone: true,
+  template: "",
+})
+class ExemploConsultaCompletaStubComponent {}
+
+@Component({
+  selector: "app-comparar-produto",
+  standalone: true,
+  template: "",
+})
+class CompararProdutoStubComponent {
+  @Input() consultaComparada: any;
+}
+
+@Component({
+  selector: "app-como-funciona",
+  standalone: true,
+  template: "",
+})
+class ComoFuncionaStubComponent {}
+
+@Component({
+  selector: "app-duvidas-frequentes",
+  standalone: true,
+  template: "",
+})
+class DuvidasFrequentesStubComponent {}
+
+@Component({
+  selector: "app-produtos",
+  standalone: true,
+  template: "",
+})
+class ProdutosStubComponent {}
+
+@Directive({
+  selector: "[appAppearRightOnScroll]",
+  standalone: true,
+})
+class AppearRightOnScrollStubDirective {}
+
+describe("ConsultaVeicularCompletaComponent", () => {
+  let fixture: ComponentFixture<ConsultaVeicularCompletaComponent>;
+  let component: ConsultaVeicularCompletaComponent;
+  let variableGlobal: VariableGlobal;
+  const mockProdutos = [
+    {
+      id: 1,
+      nome_da_consulta: "Consulta Base",
+      valor_atual: 30.9,
+      valor_promocional: 25.9,
+    },
+    {
+      id: 3,
+      nome_da_consulta: "Consulta Veicular Completa",
+      valor_atual: 69.9,
+      valor_promocional: 54.9,
+    },
+  ];
+
+  beforeEach(async () => {
+    TestBed.overrideComponent(ConsultaVeicularCompletaComponent, {
+      set: {
+        imports: [
+          CommonModule,
+          ExemploConsultaCompletaStubComponent,
+          CompararProdutoStubComponent,
+          ComoFuncionaStubComponent,
+          DuvidasFrequentesStubComponent,
+          ProdutosStubComponent,
+          AppearRightOnScrollStubDirective,
+        ],
+      },
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [ConsultaVeicularCompletaComponent],
+    }).compileComponents();
+
+    variableGlobal = TestBed.inject(VariableGlobal);
+    spyOn(variableGlobal, "getProdutos").and.returnValue(mockProdutos);
+
+    fixture = TestBed.createComponent(ConsultaVeicularCompletaComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("deve criar o componente", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("deve carregar a consulta recomendada com id 3", () => {
+    expect(variableGlobal.getProdutos).toHaveBeenCalled();
+    expect(component.consulta).toEqual(mockProdutos[1]);
+  });
+
+  it("deve exibir as informações principais da consulta na tela", () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector("h1")?.textContent).toContain(
+      "Consulta Veicular Completa",
+    );
+    expect(compiled.querySelector(".consulta .azul")?.textContent).toContain(
+      "Consulta Veicular Completa",
+    );
+    expect(compiled.querySelector(".consulta .de")?.textContent).toContain(
+      "69,90",
+    );
+    expect(compiled.querySelector(".consulta .preco")?.textContent).toContain(
+      "54,90",
+    );
+    expect(compiled.querySelector(".consulta .label")?.textContent).toContain(
+      "RECOMENDADA",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add focused unit tests for `ConsultaVeicularCompletaComponent`, stubbing heavy child dependencies while validating the retrieved produto data
- cover the Consulta Veicular Completa product page end to end with Cypress to assert the key sections and pricing details render as expected

## Testing
- `npm run coverage` *(fails: npm registry returned HTTP 403 while trying to download Angular CLI)*
- `npm run e2e` *(fails: Cypress binary unavailable because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c86ccf1428832091f8206951b26393