### PR TITLE
test: cover status pagamento screen

### DIFF
--- a/cypress/fixtures/payment-additional-statuses.json
+++ b/cypress/fixtures/payment-additional-statuses.json
@@ -1,0 +1,23 @@
+[
+  {
+    "transacao": "22222",
+    "dataPagamento": "2023-08-09T12:00:00",
+    "valorFinal": 120.0,
+    "tipoPagamento": "DEBITO",
+    "situacaoPagamento": "EM_CONTESTACAO"
+  },
+  {
+    "transacao": "33333",
+    "dataPagamento": "2023-08-10T12:30:00",
+    "valorFinal": 130.0,
+    "tipoPagamento": "CARTAO",
+    "situacaoPagamento": "EM_DISPUTA"
+  },
+  {
+    "transacao": null,
+    "dataPagamento": "2023-08-11T13:00:00",
+    "valorFinal": 140.0,
+    "tipoPagamento": "PIX",
+    "situacaoPagamento": "PROCESSANDO_PAGAMENTO"
+  }
+]


### PR DESCRIPTION
## Summary
- add unit coverage for StatusPagamentoComponent including filter usage and template status rendering
- extend Cypress specs to validate all payment statuses and search behaviour
- add fixture data for contestação, disputa and erro de pagamento scenarios

## Testing
- npm test -- --watch=false --code-coverage *(fails: npm 403 forbidden when fetching ng)*

------
https://chatgpt.com/codex/tasks/task_b_68c86cd0c0a483209baa453b88abb735