### PR TITLE
fix: provide pagar débitos service in root

### DIFF
--- a/src/app/service/pagar-debitos.service.ts
+++ b/src/app/service/pagar-debitos.service.ts
@@ -3,7 +3,9 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { VariableGlobal } from './variable.global.service';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class PagarDebitosService {
 
 


### PR DESCRIPTION
## Summary
- ensure PagarDebitosService is tree-shakable and available application-wide by providing it in root injector

## Testing
- npm test -- --watch=false *(fails: npm ERR! 403 Forbidden fetching https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_b_68cafe7d296483209bbfe7a5d72c9ba5