### PR TITLE
feat: atualizar título dinâmico da consulta company

### DIFF
--- a/src/app/consulta-company/consulta-company.component.ts
+++ b/src/app/consulta-company/consulta-company.component.ts
@@ -51,8 +51,13 @@ export class ConsultaCompanyComponent implements OnInit {
     }
   }
 
+  private atualizarTituloConsulta(tipo?: string | null): void {
+    if (tipo != null) {
+      this.titleService.setTitle(`Consulta Veicular ${tipo} - Carcheck`);
+    }
+  }
+
   ngOnInit() {
-    this.titleService.setTitle("Consulta CNPJ Completa");
     this.metaService.updateTag({
       name: "description",
       content:
@@ -72,6 +77,7 @@ export class ConsultaCompanyComponent implements OnInit {
 
     this.dadosConsulta = this.dataService.getData();
     if (this.dadosConsulta) {
+      this.atualizarTituloConsulta(this.dadosConsulta?.tipo);
       this.modalService.closeLoading();
       this.iframeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
         this.dadosConsulta.linkPesquisa
@@ -81,6 +87,7 @@ export class ConsultaCompanyComponent implements OnInit {
         .getConsultaVeiculoCompany(this.tokenConsulta)
         .then((v) => {
           this.dadosConsulta = v;
+          this.atualizarTituloConsulta(this.dadosConsulta?.tipo);
           this.iframeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
             this.dadosConsulta.linkPesquisa
           );


### PR DESCRIPTION
## Summary
- garante que o título da página de consulta company seja atualizado conforme o tipo retornado pela API
- extrai lógica de atualização do título para um método auxiliar reutilizável

## Testing
- npm run lint *(falha: ng não encontrado porque as dependências não puderam ser instaladas neste ambiente)*

------
https://chatgpt.com/codex/tasks/task_b_68caff21cef08320a7bc608f87e358f0