### PR TITLE
Implement polling workflow for debt consultation

### DIFF
--- a/src/app/service/pagar-debitos.service.ts
+++ b/src/app/service/pagar-debitos.service.ts
@@ -24,4 +24,8 @@ export class PagarDebitosService {
     return this.http.post(
       this.variableGlobal.getUrl("pinpag/gerarLinkPagamento"), dados)
   }
+
+  buscarRetorno(consultId: string): Observable<any> {
+    return this.http.get(this.variableGlobal.getUrl("pinpag/buscarRetorno/" + consultId))
+  }
 }


### PR DESCRIPTION
## Summary
- update the pagar débitos component to trigger polling after the initial consultation and persist the returned vehicle data
- add a pagar débitos service helper to fetch the polling return endpoint

## Testing
- `npm run lint` *(fails: `ng` not found because dependencies could not be installed; `npm install` is blocked by 403 errors from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68cafe6821c88320b3861cb6b2c5483d